### PR TITLE
Pagination setup to display all issues, 20 issues per page, seeing as right now github only returns 20 issues per request.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,3 +9,8 @@
 .progress {
   margin-top: 0;
 }
+
+ul.pagination {
+	display: flex;
+	justify-content: center;
+}

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
     <div class="container" id="cards">
       <div class="row">
       </div>
+
+      <ul class="pagination"></ul>
     </div>
 
     <!-- js -->

--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,25 @@
 // This is where the magic happens
 // Written by Fredrik August Madsen-Malmo (github@fredrikaugust)
 
-var URL = "https://api.github.com/repos/open-source-ideas/open-source-ideas/issues";
+// by default github paginates all responses with 30 items, we can change this by specifying the per-page property
+// Also, we need to specify what page we need so we can paginate on the frontend as well.
+var perPage = 20
+var page = window.location.href.match(/page=(\d+)/) ? window.location.href.match(/page=(\d+)/)[1] : 1
+var URL = "https://api.github.com/repos/open-source-ideas/open-source-ideas/issues?per_page="+perPage+"&page="+page;
+
 
 function display_issues () {
   $.get({
     url: URL,
-    success: function (data) {
-      show_issues_in_dom(data);
+    success: function (data, status, xhr) {
+      // the total number of pages we have in the pagination is gotten from the response header (Link)
+      // However, to extract it, this is the simplest hack I could come up with.
+      var str = xhr.getResponseHeader('Link')
+
+      // if we can't find rel=last, then this is the last page
+      pages = str.indexOf('rel="last"') > 0 ? parseInt(str[str.indexOf('rel="last"') - 4]) : page
+
+      show_issues_in_dom(data, pages);
       $('.progress').slideUp();
     }
   });
@@ -25,13 +37,17 @@ function generate_label_html (labels) {
 
 function create_issue_url (issue) {
   var loc = window.location.href;
+  // if the location ends with a slash
   if (loc.slice(-1) == '/') {
     return loc + 'issue.html?issue=' + issue;
+  } else if (loc.indexOf('?') > 0){
+    // if a url query has been applied, match the last / and replace everything onwards with the issue url
+    return loc.replace(/(?:\/[^\/\r\n]*)$/, '/') + 'issue.html?issue=' + issue;
   }
   return loc.replace(/\w+\.[^\.]+$/, '') + 'issue.html?issue=' + issue;
 }
 
-function show_issues_in_dom (issues) {
+function show_issues_in_dom (issues, pages) {
   issues.forEach(function (issue) {
     $('#cards .row').append(
       "<div class='col s12'>" +
@@ -52,6 +68,16 @@ function show_issues_in_dom (issues) {
     );
 
   });
+
+  // let's add the pagination links
+  for (var i = 1; i <= pages; i++) {
+    var class_ = page == i ? "active" : "waves-effect"
+    $('.pagination').append(
+      "<li class='" + class_ + "'>" + 
+        "<a href='" + window.location.href.replace(/(?:\/[^\/\r\n]*)$/, '') + "?page=" + i + "''>" + i +"</a>" + 
+      "</li>"
+    )
+  }
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
When we make an API call to the url https://api.github.com/repos/open-source-ideas/open-source-ideas/issues, github returns a paginated response, with only 30 issues per page. Hence to show all items, we need to create our own frontend pagination. That's what I've done with this pull request. 

You can check out the working pagination at https://itope84.github.io/open-source-ideas.github.io/, I set it to 20 issues per page, but this can be easily modified by changng the perPage variable in main.js.